### PR TITLE
Update meld

### DIFF
--- a/meld.rb
+++ b/meld.rb
@@ -1,8 +1,8 @@
 class Meld < Formula
   desc "A visual diff tool for developers"
   homepage "http://meldmerge.org"
-  url "https://download.gnome.org/sources/meld/3.14/meld-3.14.0.tar.xz"
-  sha256 "430e2936b787c90ffa0999d3c94611fcaa64ca1920933f31550d5b931b4f103c"
+  url "https://download.gnome.org/sources/meld/3.14/meld-3.14.1.tar.xz"
+  sha256 "f43f750ed00da7925ecc70d6c5fc398c46ccf5af2f9e14b42c9a8afc7fbc06a3"
 
   bottle do
     cellar :any


### PR DESCRIPTION
  Features:
- Offer to open binary files externally (Pratik Dayama)
- Use locale-based default encodings (Kai Willadsen)
  
  Fixes:
- Fix crash with some GTK+ versions when using --output (Kai Willadsen)
- Fix merge-all action not working at all (Kai Willadsen)
- Fix creating patches with unicode path names (Kai Willadsen)
- Fix copy-to-clipboard option in patch dialog (Kai Willadsen)
- Fix diffmap alignment for new GTK+ allocation behaviour (Kai Willadsen)
- Improve float accuracy in folder comparison timestamp resolution (Kai Willadsen)
- Fix default SVN keyword filter to escape $ characters (Kai Willadsen)
- Fix display of unicode --help from command line (Kai Willadsen)
- Fix keyboard shortcut docs (Kai Willadsen)
- Don't incorrectly show identical notification for changed folder comparisons (Kai Willadsen)
